### PR TITLE
Feature/upgrade onboard version

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,23 +1,13 @@
 import { ExternalLinkIcon } from "@heroicons/react/outline";
-import {
-  ConnectOptions,
-  DisconnectOptions,
-  WalletState,
-} from "@web3-onboard/core";
-import { useSetChain } from "@web3-onboard/react";
+import { useConnectWallet, useSetChain } from "@web3-onboard/react";
 import useTranslation from "next-translate/useTranslation";
 import { useEffect } from "react";
 import { Button } from "../components";
 import { BLOCK_EXPLORER_URL, switchChain } from "../helpers";
 
-interface HeaderProps {
-  wallet: WalletState;
-  connect: (options: ConnectOptions) => Promise<void>;
-  disconnect: (options: DisconnectOptions) => Promise<void>;
-}
-
-export default function Header({ wallet, connect, disconnect }: HeaderProps) {
+export default function Header() {
   const { t } = useTranslation("common");
+  const [{ wallet }, connect, disconnect] = useConnectWallet();
   const [{}, setChain] = useSetChain();
   const CHAIN_ID = process.env.NEXT_CHAIN_ID;
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@heroicons/react": "^1.0.5",
     "@web3-onboard/core": "^2.0.11",
     "@web3-onboard/injected-wallets": "^2.0.2",
-    "@web3-onboard/react": "^2.0.3",
+    "@web3-onboard/react": "^2.0.6",
     "@web3-onboard/walletconnect": "^2.0.1",
     "ethers": "^5.5.2",
     "next": "12.0.7",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import { initOnboard } from "../services";
 import "../styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const [{ wallet }, connect, disconnect] = useConnectWallet();
+  const [{}, connect] = useConnectWallet();
   const connectedWallets = useWallets();
   const [onboard, setOnboard] = useState<OnboardAPI>();
 
@@ -42,8 +42,8 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <div className="m-4">
-      <Header wallet={wallet} disconnect={disconnect} connect={connect} />
-      <Component wallet={wallet} {...pageProps} />
+      <Header />
+      <Component {...pageProps} />
     </div>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import { initOnboard } from "../services";
 import "../styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const [{}, connect] = useConnectWallet();
+  const [{ wallet }, connect] = useConnectWallet();
   const connectedWallets = useWallets();
   const [onboard, setOnboard] = useState<OnboardAPI>();
 
@@ -39,6 +39,12 @@ function MyApp({ Component, pageProps }: AppProps) {
       setWalletFromLocalStorage();
     }
   }, [onboard, connect]);
+
+  useEffect(() => {
+    if (!wallet?.provider) {
+      window.localStorage.removeItem("connectedWallets");
+    }
+  }, [wallet]);
 
   return (
     <div className="m-4">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,6 @@
-import { WalletState } from "@web3-onboard/core";
 import type { NextPage } from "next";
-interface HomeProps {
-  wallet: WalletState;
-}
 
-const Home: NextPage = ({ wallet }: HomeProps) => {
+const Home: NextPage = () => {
   return (
     <div
       className="bg-cover"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,10 +1165,19 @@
     joi "^17.4.2"
     rxjs "^7.5.2"
 
-"@web3-onboard/common@^2.0.1", "@web3-onboard/common@^2.0.2":
+"@web3-onboard/common@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@web3-onboard/common/-/common-2.0.2.tgz#e5bcda22a6e14bd66d2f7d9b7ef9329f0c086cac"
   integrity sha512-foFyWJIqmv83lhqyXqwW8vUdOULdRvIvj4ScxFcd3hGDYJArKnnocvAIcAAfP7Rmte3TDWejuFKz+H4dmaoUUA==
+  dependencies:
+    ethers "5.5.4"
+    joi "^17.4.2"
+    rxjs "^7.5.2"
+
+"@web3-onboard/common@^2.0.3":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/common/-/common-2.0.4.tgz#468227fe864bb8465db38e8534adc0c7f6583884"
+  integrity sha512-oxkcMIsLERBsKo5hieoZ44ok9JE81v3q4YYrz53g9P2bXhW+r0sFtHc6b2kh6S2ue2rCbT1yW8cIYMM/EKwUsw==
   dependencies:
     ethers "5.5.4"
     joi "^17.4.2"
@@ -1190,10 +1199,10 @@
     svelte "^3.46.4"
     svelte-i18n "^3.3.13"
 
-"@web3-onboard/core@^2.0.6":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.0.10.tgz#4aed26c9e7eee58ec9d7d1e71ddad6adee0075e8"
-  integrity sha512-4AvZKNCZLLHbDhueCBz5jvfRE9dQzEpsoA2lBVpwtXHhJzRRdYjVTUSBx1DgflzCnZUdOEuECSTwvM0OI3PtwQ==
+"@web3-onboard/core@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.1.0.tgz#2675cfecd200c0028c7a11cd04e77ddd506bcd4a"
+  integrity sha512-WPVOrxWSnYXCQ0Ahen5dMjR2Q3G+g/dRSjLSqUn3dBzb6bzmN6v8O2yxMy9R9bM/wp89xzTwyRpaxKGT/4xvyQ==
   dependencies:
     "@web3-onboard/common" "^2.0.2"
     bowser "^2.11.0"
@@ -1215,13 +1224,13 @@
     joi "^17.4.2"
     lodash.uniqby "^4.7.0"
 
-"@web3-onboard/react@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/react/-/react-2.0.3.tgz#3e0edea32f175eb2b3f83bbfd6b4b0d0fdac4e94"
-  integrity sha512-EwdCvEUnOjhhtn3JHAsA+cxRnZyseMuM5qpHsGA2YX5NV3BwZjHavwpxYRIPooHhVxB6GsUVzBILZeWTrOoGQw==
+"@web3-onboard/react@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/react/-/react-2.0.6.tgz#337fe2c7a6500260ba01dc6dec20fa248f997917"
+  integrity sha512-ww3UdPnezXtITfCpQDP2QMEn61CiWM5V72XJdLNpRm/4U/R1a6gjoap5++UDLKUJ6WJkJtXU5QNuAFqhv60dsw==
   dependencies:
-    "@web3-onboard/common" "^2.0.1"
-    "@web3-onboard/core" "^2.0.6"
+    "@web3-onboard/common" "^2.0.3"
+    "@web3-onboard/core" "^2.1.0"
 
 "@web3-onboard/walletconnect@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
## Description
The Blocknative team upgraded the `@web3-onboard/react` package so the wallet state from the hook is now working as expected. Fixes #11 

## Checklist
- [x]  Upgrade to latest version of `@web3-onboard/react`
- [x] Get wallet state from `useConnectWallet` hook instead of passing through props