### PR TITLE
add disable modals on auto connect

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -34,7 +34,12 @@ function MyApp({ Component, pageProps }: AppProps) {
 
     if (previouslyConnectedWallets?.length) {
       async function setWalletFromLocalStorage() {
-        await connect({ autoSelect: previouslyConnectedWallets[0] });
+        await connect({
+          autoSelect: {
+            label: previouslyConnectedWallets[0],
+            disableModals: true,
+          },
+        });
       }
       setWalletFromLocalStorage();
     }


### PR DESCRIPTION
Stop onboard from showing the ui when a wallet is auto connected. 

https://github.com/simpleweb/ethereum-base/issues/17
